### PR TITLE
Change from using OMAS.jl to IMASDD.jl to access IMAS data structure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ author = ["Luke Stagner <stagnerl@fusion.gat.com>"]
 version = "0.2.0"
 
 [deps]
+IMASDD = "06b86afa-9f21-11ec-2ef8-e51b8960cfc5"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-OMAS = "91cfaa06-6526-4804-8666-b540b3feef2f"
 PolygonOps = "647866c9-e3ac-4575-94e7-e3d426903924"
 
 [compat]

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,6 @@
 mutable struct GEQDSKFile
     file::String                    # Source file
+    time::Float64                   # Time of the equilibrium reconstruction, in seconds
     nw::Int                         # Number of horizontal R grid points
     nh::Int                         # Number of vertical Z grid points
     r::AbstractRange{Float64}       # R grid points
@@ -75,6 +76,7 @@ function readg(gfile)
     s = split(desc)
 
     time = Meta.parse(s[end-3])
+    time /= 1000.0  # Assume it was written in ms and convert to s
     idum = Meta.parse(s[end-2])
     nw = Meta.parse(s[end-1])
     nh = Meta.parse(s[end])
@@ -160,7 +162,7 @@ function readg(gfile)
     z = range(zmid - 0.5*zdim, zmid + 0.5*zdim, length=nh)
     psi = range(simag, sibry, length=nw)
 
-    g = GEQDSKFile(gfile, nw,nh,r,z,rdim,zdim,rleft,zmid,nbbbs,rbbbs,zbbbs,limitr,rlim,zlim,
+    g = GEQDSKFile(gfile,time,nw,nh,r,z,rdim,zdim,rleft,zmid,nbbbs,rbbbs,zbbbs,limitr,rlim,zlim,
                    rcentr,bcentr,rmaxis,zmaxis,simag,sibry,psi,current,fpol,pres,ffprim,pprime,
                    qpsi,psirz,rhovn)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 using Interpolations: Interpolations
 using PolygonOps: PolygonOps
-using OMAS: OMAS
+using IMASDD: IMASDD
 
 function triangularity(g::GEQDSKFile)
     Rmin, Rmax = extrema(filter(!iszero,g.rbbbs))
@@ -68,13 +68,13 @@ psi: polidal magnetic flux / T m^2
 """
 function fluxinfo(r::Vector, z::Vector, psi::Matrix)
     # Take some gradients
-    dpsidr, dpsidz = OMAS.gradient(r, z, psi)
+    dpsidr, dpsidz = IMASDD.gradient(r, z, psi)
     br = -dpsidz ./ r
     bz = dpsidr ./ r
     bpol2 = (br .^ 2) .+ (bz .^ 2)
     bpol = real.(sqrt.((br .^ 2) .+ (bz .^ 2)))
-    d2psidr2, d2psidrdz = OMAS.gradient(r, z, dpsidr)
-    d2psidzdr, d2psidz2 = OMAS.gradient(r, z, dpsidz)
+    d2psidr2, d2psidrdz = IMASDD.gradient(r, z, dpsidr)
+    d2psidzdr, d2psidz2 = IMASDD.gradient(r, z, dpsidz)
     d = d2psidr2 .* d2psidz2 .- d2psidrdz .^ 2
     return (br, bz, bpol, d)
 end


### PR DESCRIPTION
- OMAS.jl is a stripped-down version of IMASDD.jl. The purpose of both is to access the IMAS data schema, but IMASDD has more features.
  - IMASDD was being kept private, but is now being publicly released, so it is usable. @orso82 
- Add time as a field in GEQDSKFile structure
  - Close #5 @anchal-physics
