### PR TITLE
Parsing time in EFIT header

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -66,14 +66,8 @@ function read_array2d(t,n,m)
     return data'
 end
 
-function readg(gfile; set_time=nothing)
-
-    isfile(gfile) || error("$(gfile) does not exist")
-
-    f = open(gfile)
-
-    desc = readline(f)
-    s = split(desc)
+function parse_gfile_header(headerline::String; set_time=nothing)
+    s = split(headerline)
 
     if !isnothing(set_time)
         time = set_time
@@ -109,6 +103,19 @@ function readg(gfile; set_time=nothing)
     idum = Meta.parse(s[end-2])
     nw = Meta.parse(s[end-1])
     nh = Meta.parse(s[end])
+    println("time = ", time)
+
+    return idum, time, nw, nh
+end
+
+function readg(gfile; set_time=nothing)
+
+    isfile(gfile) || error("$(gfile) does not exist")
+
+    f = open(gfile)
+
+    desc = readline(f)
+    idum, time, nw, nh = parse_gfile_header(desc, set_time=set_time)
 
     token = file_numbers(f)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -76,7 +76,31 @@ function readg(gfile)
     s = split(desc)
 
     time = Meta.parse(s[end-3])
-    time /= 1000.0  # Assume it was written in ms and convert to s
+    time_warning = "Warning: EFIT.jl could not convert time from ms (assumed units) to s"
+    omfit_advice = "Options for proceeding include editing the header in your gEQDSK file or trying to use OMFIT:" *
+        "python: `OMFITgeqdsk(file).to_omas().save('ods.jl')`"
+    try
+        time /= 1000.0  # Assume it was written in ms and convert to s
+    catch e
+        if time isa String
+            rg2 = r"([[:digit:]]+|(?:[[:punct:]]|[[:blank:]])+)"
+            try
+                time = parse(Int,collect(eachmatch(rg2, time))[1][1])
+            catch e
+                println(
+                    time_warning,
+                    ", even after trying really hard with regex and everything. Time is ",
+                    time,
+                    ". ",
+                    omfit_advice,
+                )
+            end
+            time /= 1000.0
+        else
+            println(time_warning, ". Time is ", time, ". ", omfit_advice)
+        end
+    end
+
     idum = Meta.parse(s[end-2])
     nw = Meta.parse(s[end-1])
     nh = Meta.parse(s[end])

--- a/src/io.jl
+++ b/src/io.jl
@@ -66,7 +66,7 @@ function read_array2d(t,n,m)
     return data'
 end
 
-function readg(gfile)
+function readg(gfile; set_time=nothing)
 
     isfile(gfile) || error("$(gfile) does not exist")
 
@@ -85,19 +85,26 @@ function readg(gfile)
         if time isa String
             rg2 = r"([[:digit:]]+|(?:[[:punct:]]|[[:blank:]])+)"
             try
-                time = parse(Int,collect(eachmatch(rg2, time))[1][1])
+                time = parse(Int,collect(eachmatch(rg2, time))[1][1]) / 1000.0
             catch e
-                println(
-                    time_warning,
-                    ", even after trying really hard with regex and everything. Time is ",
-                    time,
-                    ". ",
-                    omfit_advice,
-                )
+                if set_time == nothing
+                    println(
+                        time_warning,
+                        ", even after trying really hard with regex and everything. Time is ",
+                        time,
+                        ". ",
+                        omfit_advice,
+                    )
+                else
+                    time = set_time
+                end
             end
-            time /= 1000.0
         else
-            println(time_warning, ". Time is ", time, ". ", omfit_advice)
+            if set_time is nothing
+                println(time_warning, ". Time is ", time, ". ", omfit_advice)
+            else
+                time = set_time
+            end
         end
     end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -103,7 +103,6 @@ function parse_gfile_header(headerline::String; set_time=nothing)
     idum = Meta.parse(s[end-2])
     nw = Meta.parse(s[end-1])
     nh = Meta.parse(s[end])
-    println("time = ", time)
 
     return idum, time, nw, nh
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -75,35 +75,33 @@ function readg(gfile; set_time=nothing)
     desc = readline(f)
     s = split(desc)
 
-    time = Meta.parse(s[end-3])
-    time_warning = "Warning: EFIT.jl could not convert time from ms (assumed units) to s"
-    omfit_advice = "Options for proceeding include editing the header in your gEQDSK file or trying to use OMFIT:" *
-        "python: `OMFITgeqdsk(file).to_omas().save('ods.jl')`"
-    try
-        time /= 1000.0  # Assume it was written in ms and convert to s
-    catch e
-        if time isa String
-            rg2 = r"([[:digit:]]+|(?:[[:punct:]]|[[:blank:]])+)"
-            try
-                time = parse(Int,collect(eachmatch(rg2, time))[1][1]) / 1000.0
-            catch e
-                if set_time == nothing
-                    println(
+    if !isnothing(set_time)
+        time = set_time
+    else
+        time = Meta.parse(s[end-3])
+        time_warning = "EFIT.jl could not convert time from ms (assumed units) to s"
+        omfit_advice = "Options for proceeding include:\n" *
+                       "i)    Editing the header in your gEQDSK file.\n" *
+                       "ii)   Trying to use OMFIT: python: `OMFITgeqdsk(file).to_omas().save('ods.jl')`\n" *
+                       "iii)  Set the time manually with the `set_time` keyword argument.\n"
+        try
+            time /= 1000.0  # Assume it was written in ms and convert to s
+        catch e
+            if time isa String
+                rg2 = r"([[:digit:]]+|(?:[[:punct:]]|[[:blank:]])+)"
+                try
+                    time = parse(Int, collect(eachmatch(rg2, time))[1][1]) / 1000.0
+                catch e
+                    error(
                         time_warning,
-                        ", even after trying really hard with regex and everything. Time is ",
+                        ", even after trying really hard with regex and everything.\nTime is ",
                         time,
-                        ". ",
-                        omfit_advice,
+                        ". \n",
+                        omfit_advice
                     )
-                else
-                    time = set_time
                 end
-            end
-        else
-            if set_time is nothing
-                println(time_warning, ". Time is ", time, ". ", omfit_advice)
             else
-                time = set_time
+                error(time_warning, ".\nTime is parsed as ", time," of type ", typeof(time), ". ", omfit_advice)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,32 +62,34 @@ end
 
 @testset "parse header" begin
     headers = [
-        "EFITD    00/00/2008    #002296  0200ms Convert   0 257 513",
+        "   EFITD    00/00/2008    #002296  0200ms Convert   0 257 513",
+        "   EFITD   11/23/2020    #184833  3600             3  65  65",
     ]
     times = [
         0.2,
+        3.6,
     ]
     expect_exception = [
         true,
+        false,
     ]
-    the_set_time = 2000
+    the_set_time = 0.2
     for set_time in [the_set_time, nothing]
-        for i in 1:length(headers)
+        for i in eachindex(headers)
             try
                 idum, time, nw, nh = EFIT.parse_gfile_header(headers[i]; set_time=set_time)
-            catch
-                if expect_exception[i]
-                    println("got the expected exception", i)
-                else
-                    raise
-                end
-            else
-                println("time = ", time, ", times[i] = ", times[i])
-                if isnothing(set_time)
-                    @test time == the_set_time / 1000.0
+                if !isnothing(set_time)
+                    @test time == the_set_time
                 else
                     @test time == times[i]
                 end
+            catch
+                if expect_exception[i]
+                    println("Got the expected exception")
+                else
+                    println("Got the unexpected exception")
+                end
+                @test expect_exception[i]
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using EFIT
+import EFIT
 
 g = readg(EFIT.test_gfile)
 g2 = readg(EFIT.test_gfile2)
@@ -57,4 +58,37 @@ lt, ut = triangularity(g)
     @test xpsins[2] > (1 + psin_tolerance)
     @test (xrs[2] > 1.2) & (xrs[2] < 1.33)
     @test (xzs[2] > 1.04) & (xzs[2] < 1.17)
+end
+
+@testset "parse header" begin
+    headers = [
+        "EFITD    00/00/2008    #002296  0200ms Convert   0 257 513",
+    ]
+    times = [
+        0.2,
+    ]
+    expect_exception = [
+        true,
+    ]
+    the_set_time = 2000
+    for set_time in [the_set_time, nothing]
+        for i in 1:length(headers)
+            try
+                idum, time, nw, nh = EFIT.parse_gfile_header(headers[i]; set_time=set_time)
+            catch
+                if expect_exception[i]
+                    println("got the expected exception", i)
+                else
+                    raise
+                end
+            else
+                println("time = ", time, ", times[i] = ", times[i])
+                if isnothing(set_time)
+                    @test time == the_set_time / 1000.0
+                else
+                    @test time == times[i]
+                end
+            end
+        end
+    end
 end


### PR DESCRIPTION
- Try splitting numeric digits from the string that should have time in it
- Use try/catch to avoid totally failing
- Issue a warning if parsing fails (user has to deal with assigning time)
- Close #7 @anchal-physics