### PR TITLE
Fix parsing of CHEASE gEQDSK files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EFIT"
 uuid = "cda752c5-6b03-55a3-9e33-132a441b0c17"
 author = ["Luke Stagner <stagnerl@fusion.gat.com>"]
-version = "0.2.0"
+version = "1.0.0"
 
 [deps]
 IMASDD = "06b86afa-9f21-11ec-2ef8-e51b8960cfc5"

--- a/src/io.jl
+++ b/src/io.jl
@@ -53,7 +53,15 @@ end
 function read_array(t,n)
     data = zeros(n)
     for i=1:n
-        data[i] = take!(t)
+        try
+            data[i] = take!(t)
+        catch e
+            if isa(e, InvalidStateException)
+                # InvalidStateException when Channel is closed
+            else
+                rethrow(e)
+            end
+        end
     end
     return data
 end
@@ -61,7 +69,15 @@ end
 function read_array2d(t,n,m)
     data = zeros(n,m)
     for i=1:n, j=1:m
-        data[i,j] = take!(t)
+        try
+            data[i,j] = take!(t)
+        catch e
+            if isa(e, InvalidStateException)
+                # InvalidStateException when Channel is closed
+            else
+                rethrow(e)
+            end
+        end
     end
     return data'
 end
@@ -114,7 +130,7 @@ function readg(gfile; set_time=nothing)
     f = open(gfile)
 
     desc = readline(f)
-    idum, time, nw, nh = parse_gfile_header(desc, set_time=set_time)
+    idum, time, nw, nh = parse_gfile_header(desc; set_time)
 
     token = file_numbers(f)
 


### PR DESCRIPTION
This PR fixes parsing of CHEASE gEQDSK files, which used to work with version 0.1.0.
A missing `rhovn` quantity was not handled correctly

Also, I'd like to bump the version of the package to be v1.0.0, since the API of EFIT.jl has been stable for a long time.