### PR TITLE
writeg G-EQDSK file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,11 @@ version = "1.0.2"
 IMASdd = "c5a45a97-b3f9-491c-b9a7-aa88c3bc0067"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 PolygonOps = "647866c9-e3ac-4575-94e7-e3d426903924"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 IMASdd = "2"
 Interpolations = "0.14.7, 0.15"
 PolygonOps = "0.1"
+Printf = "1.11.0"
 julia = "^1.2"

--- a/src/EFIT.jl
+++ b/src/EFIT.jl
@@ -3,7 +3,7 @@ __precompile__()
 module EFIT
 
 include("io.jl")
-export readg, GEQDSKFile
+export readg, writeg, GEQDSKFile
 
 include("utils.jl")
 export triangularity, ellipticity, elongation, minor_radius, major_radius, aspect_ratio, elevation

--- a/src/io.jl
+++ b/src/io.jl
@@ -34,6 +34,18 @@ mutable struct GEQDSKFile
     rhovn::Vector{Float64}          # Square root of toroidal flux, normalized
 end
 
+# Define hash function using fieldnames and getfield
+function Base.hash(x::GEQDSKFile, h::UInt)
+    for field in fieldnames(GEQDSKFile)
+        h = hash(getfield(x, field), h)
+    end
+    return h
+end
+# Define == using fieldnames and getfield
+Base.:(==)(a::GEQDSKFile, b::GEQDSKFile) = all(field -> getfield(a, field) == getfield(b, field), fieldnames(GEQDSKFile))
+# Define isequal using fieldnames and getfield
+Base.isequal(a::GEQDSKFile, b::GEQDSKFile) = all(field -> isequal(getfield(a, field), getfield(b, field)), fieldnames(GEQDSKFile))
+
 function Base.show(io::IO, g::GEQDSKFile)
     print(io,"GEQDSKFile: \"",g.file,"\"")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,3 +94,31 @@ end
         end
     end
 end
+
+@testset "writeg" begin
+
+    for test_gfile in [EFIT.test_gfile, EFIT.test_gfile2]
+
+        ori_g = readg(EFIT.test_gfile)
+
+        # Create and write a tmporary EQDSK file
+        (tmp_filename, ~) = Base.mktemp()
+        writeg(ori_g, tmp_filename; desc="\nHello, can you read me?\n\n")
+
+        # Read the temporary EQDSK file
+        new_g = readg(tmp_filename)
+
+        # Match the "file" name for a fair comparison
+        ori_g.file = "we got the same name for a fair comparison"
+        new_g.file = "we got the same name for a fair comparison"
+
+        # Check if new_g is equivalent to ori_g
+        @test new_g == ori_g
+        @test isequal(new_g, ori_g)
+
+        # Delete temporary file
+        rm(tmp_filename, force=true)
+    end
+
+
+end


### PR DESCRIPTION
@orso82  @bclyons12 @eldond 
This Pull Request introduces the implementation of the **"writeg"** function in EFIT.jl, which serves as the counterpart to the existing readg function.

### Overview of "writeg" function:
The **"writeg"** function is designed to take a GEQDSKFile struct and write it as an ASCII file in the G_EQDSK format to disk.

### Input/Output Details:
Input 1: g::GEQDSKFile — The GEQDSKFile struct containing the data to be written.

Input 2: filename::String — The name of the file to which the data will be written.

Keyword Argument: desc::String="description" — A description that can be added to the file header (optional).

Output: Bool — Returns true on successful write operation, or false if the write operation fails.

### Helper functions to compare GEQDSKFile structs
In addition to the writeg function, some helper functions were implemented to facilitate hash-based comparison of GEQDSKFile structs.

One can now compare two GEQDSKFile structs for equality using:
```julia
g1 == g2
isequal(g1, g2)
```

### Tests:
These helper functions were used in runtests.jl to validate the correctness of the writeg function, ensuring that the output file is properly written and the data is accurately represented.
